### PR TITLE
Added Common Cathode display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The first mechanism frees the user from the load of calling the refreshing metho
 
 |Method | Parameters|
 |---|---|
-|**_TM74HC595LedTube_** |uint8_t **sclk**, uint8_t **rclk**, uint8_t **dio**|
+|**_TM74HC595LedTube_** |uint8_t **sclk**, uint8_t **rclk**, uint8_t **dio**(, bool **commAnode**)|
 |**begin()**|None|
 |**blink()**|None|
 ||unsigned long **onRate** (,unsigned long **offRate**)|
@@ -64,18 +64,20 @@ The first mechanism frees the user from the load of calling the refreshing metho
 ## **Methods definition and use description**
 
 ---
-### **TM74HC595LedTube**(uint8_t **sclk**, uint8_t **rclk**, uint8_t **dio**)
+### **TM74HC595LedTube**(uint8_t **sclk**, uint8_t **rclk**, uint8_t **dio**, bool **commAnode**)
 ### Description:  
-Class constructor, create an instance of the class for each display to use. There's no need to configure the pins before calling the method, as the constructor takes care of the task.  
+Class constructor, creates an instance of the class for each display to use. There's no need to configure the pins before calling the method, as the constructor takes care of the task.  
 ### Parameters:  
 **sclk:** uint8_t (unsigned char), passes the pin number that is connected to the sclk pin of the display (the **SH_CP** pin of the shift register if working in a custom display). The pin must be free to be used as a digital output.  
 **rclk:** uint8_t (unsigned char), passes the pin number that is connected to the rclk pin of the display (the **ST_CP** pin of the shift register if working in a custom display). The pin must be free to be used as a digital output.  
-**dio:** uint8_t (unsigned char), passes the pin number that is connected to the dio pin of the display (the **DS** pin of the shift register if working in a custom display). The pin must be free to be used as a digital output.
+**dio:** uint8_t (unsigned char), passes the pin number that is connected to the dio pin of the display (the **DS** pin of the shift register if working in a custom display). The pin must be free to be used as a digital output.  
+**commAnode** boolean, optional, indicates if the display is built with common anode 7 segment led digits (true, default value), or using common cathode 7 segment. Using one kind of digits or the other, usually means that the lit leds are activated sending low bits in their respective loctation (common anode) or set bits (common cathode), but of course that is the result of the hardware implementation. Usually the use of 74HC595 shift registers is completed using common anode digits, but this optional parameter is given to get the display working otherwise.  
 ### Return value:  
 The object created.
 
 ### Use example:  
 **`TM74HC595LedTube myLedDisp(6, 7, 10);`**
+**`TM74HC595LedTube myLedDisp(6, 7, 10, false);`**
 
 ---
 ### **begin**();

--- a/examples/setWaitCharExample/setWaitCharExample.ino
+++ b/examples/setWaitCharExample/setWaitCharExample.ino
@@ -38,7 +38,7 @@ void loop(){
   //Print a message telling a "configuration" will take place
   testResult = myLedDispOne.print("JuSt");
   delay(1000);
-  testResult = myLedDispOne.print(3, false);
+  testResult = myLedDispOne.print(4, false);
   delay(1000);
   testResult = myLedDispOne.print("SeCS");
   delay(1000);
@@ -49,13 +49,26 @@ void loop(){
 
   //Setting the wait() method to keep the display alive while configuring
   testResult = myLedDispOne.wait(250);
-  delay(3000);
+  delay(4000);
 
   //Stop de waiting displayed
   testResult = myLedDispOne.noWait();
 
 //====================================>> Second example
+  //Change de wait character to _
+  testResult = myLedDispOne.print("chnG");
+  delay(1000);
+  testResult = myLedDispOne.print("char");
+  delay(1000);
+  testResult = myLedDispOne.print("to .");
+  delay(1000);
+  testResult = myLedDispOne.setWaitChar('.');
+  
+  testResult = myLedDispOne.wait();
+  delay(3000);
+  testResult = myLedDispOne.noWait();
 
+//====================================>> Third example
   //Change de wait character to _
   testResult = myLedDispOne.print("chnG");
   delay(1000);
@@ -69,7 +82,7 @@ void loop(){
   delay(3000);
   testResult = myLedDispOne.noWait();
 
-//====================================>> Third example
+//====================================>> Fourth example
   //Change de wait character to o
   testResult = myLedDispOne.print("chnG");
   delay(1000);
@@ -85,7 +98,7 @@ void loop(){
   //Stop de waiting displayed
   testResult = myLedDispOne.noWait();
   
-//====================================>> Fourth example
+//====================================>> Fifth example
   //Change de wait character to 8
   testResult = myLedDispOne.print("chnG");
   delay(1000);

--- a/library.json
+++ b/library.json
@@ -1,9 +1,9 @@
 {
     "name": "FourBitLedDigitalTube",
-    "version": "1.11.0",
+    "version": "1.12.0",
     
-    "description": "7 segment 4 digits LED display easy to use and powerful library for modules based on two TM74HC595 (or similar) shift registers chips. Developed for the cheap and popular '4-bit Led Digital Tube Module' (**_and for all the custom made displays as: GIANTS COUNTERS, TIMERS, PRICING DISPLAYS, etc._**)  based on two TM74HC595 (or similar) shift registers, the main focus was set on: ease of use, flexibility and basic prevention of 'misrepresentation' errors.",
-    "keywords": "7 Segment, 4 digits, LED, display, print, blink, gauge, floating point, negative, shift register, counter, tally counter, click counter",
+    "description": "7 segment 4 digits LED display easy to use and powerful library for modules based on 74HC595 (or similar) shift registers chips. Developed for the cheap and popular '4-bit Led Digital Tube Module' (**_and for all the custom made displays as: GIANTS COUNTERS, TIMERS, PRICING DISPLAYS, etc._**)  based on two 74HC595 (or similar) shift registers, the main focus was set on: ease of use, flexibility and basic prevention of 'misrepresentation' errors.",
+    "keywords": "7 Segment, 4 digits, 74HC595, LED, display, print, blink, gauge, floating point, negative, shift register, counter, tally counter, click counter",
     
     "repository":
     {

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=FourBitLedDigitalTube
-version=1.11.0
+version=1.12.0
 author=Gabriel D. Goldman <gdgoldman67@hotmail.com>
 maintainer=Gabriel D. Goldman <gdgoldman67@hotmail.com>
-sentence=7 segment 4 digits LED display easy to use and powerful library for modules based on two TM74HC595 (or similar) shift registers chips
-paragraph=Developed for the cheap and popular '4-bit Led Digital Tube Module' (**_and for all the custom made displays as: GIANTS COUNTERS, TIMERS, PRICING DISPLAYS, etc._**)  based on two TM74HC595 (or similar) shift registers, the main focus was set on: ease of use, flexibility and basic prevention of 'misrepresentation' errors.
+sentence=7 segment 4 digits LED display easy to use and powerful library, for modules based on two 74HC595 shift registers chips ('4-bit Led Digital Tube Module')
+paragraph=Developed for the cheap and popular '4-bit Led Digital Tube Module' (**_and for all the custom made displays as: GIANTS COUNTERS, TIMERS, PRICING DISPLAYS, etc._**)  based on 74HC595 shift registers, the main focus was set on: ease of use, flexibility and basic prevention of 'misrepresentation' errors.
 category=Display
 url=https://github.com/GabyGold67/FourBitLedDigitalTube
 depends=TimerOne (>=1.1.1)

--- a/src/FourBitLedDigitalTube.h
+++ b/src/FourBitLedDigitalTube.h
@@ -23,6 +23,7 @@ protected:
     uint8_t _sclk;
     uint8_t _rclk;
     uint8_t _dio;
+    bool _commAnode {true};
     uint8_t _dispInstNbr{0};
     uint8_t _digit[4];
     bool _blinkMask[4]{true, true, true, true};
@@ -34,7 +35,7 @@ protected:
     unsigned long _blinkOffRate{500};
 
     String _charSet{"0123456789AabCcdEeFGHhIiJLlnOoPqrStUuY-_=~* ."}; // for using indexOf() method
-    uint8_t _charLeds[45] = {
+    uint8_t _charLeds[45] = {   //Values valid for a Common Anode display. For a Common Cathode display values must be logically bit negated
         0xC0, // 0
         0xF9, // 1
         0xA4, // 2
@@ -83,6 +84,7 @@ protected:
     };
     
     uint8_t _space {0xFF};
+    uint8_t _dot {0x7F};
 
     void send(const uint8_t &content);
     void fastSend(uint8_t content);
@@ -90,7 +92,7 @@ protected:
     void updWaitState();
 
 public:
-    TM74HC595LedTube(uint8_t sclk, uint8_t rclk, uint8_t dio);
+    TM74HC595LedTube(uint8_t sclk, uint8_t rclk, uint8_t dio, bool commAnode = true);
 
     bool begin();
     bool blink();


### PR DESCRIPTION
_ Added a "common cathode" display option as opposed to the "common anode" single original implementation. Using one kind of digits or the other, usually means that the lit leds are activated sending low bits in their respective location (common anode) or set bits (common cathode), but of course that is the result of the hardware implementation. This optional parameter is given to get the display working otherwise.
_ Modified de definition of "space", "dot" and "waitChar" according to the new common "cathode option".
